### PR TITLE
Update BrowserUpload#options to include 'app-order' metadata

### DIFF
--- a/lib/s3_bunny/browser_upload.rb
+++ b/lib/s3_bunny/browser_upload.rb
@@ -3,6 +3,7 @@ module S3Bunny
     attr_writer :options, :key_generator, :success_action_status, :acl, :content_length_range, :signature_expiration
     attr_accessor :resource_type
     attr_accessor :resource_id
+    attr_accessor :order
 
     def initialize(region:, credentials:, bucket_name:)
       @region = region
@@ -26,6 +27,7 @@ module S3Bunny
         metadata: {
           'app-resource-type' => resource_type,
           'app-resource-id' =>   resource_id.to_s,
+          'app-order' => order.to_s,
           'original-filename' => '${filename}'   # this is AWS S3 keywoard suggar.
         }
       }


### PR DESCRIPTION
* Never actually forked a project and opened a PR @equivalent , so hopefully this will work 😄 
* I know you mentioned using a mechanism like `attr_accessor :custom_fields` but not entirely sure how you envisage this being implemented, as I need to ensure I can fetch `app-order` metadata in the `Pobble` application code. 
* Based on local testing, this seems to give me the info I require